### PR TITLE
Feature - Blockbreaks Count against Durability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.8.03</version>
+	<version>3.8.04</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.8.01</version>
+	<version>3.8.02</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 
@@ -57,8 +57,8 @@
         </dependency>
 		<dependency>
 			<groupId>vg.civcraft.mc.bettershards</groupId>
-			<artifactId>BetterShards</artifactId>
-			<version>1.4</version>
+			<artifactId>BetterShardsBukkit</artifactId>
+			<version>1.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.8.02</version>
+	<version>3.8.03</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -81,22 +81,28 @@ public class BlockListener implements Listener {
 	public void comparatorPlaceCheck(BlockPlaceEvent event)
 	{
 		//We only care if they are placing a comparator
-		if(event.getBlockPlaced().getType() == Material.REDSTONE_COMPARATOR_OFF)
-		{
-			Comparator comparator = (Comparator)event.getBlockPlaced().getState().getData();
-			Block block = event.getBlockPlaced().getRelative(comparator.getFacing().getOppositeFace());
-			//We only care if the comparator is going placed against something with an inventory
-			if(block.getState() instanceof InventoryHolder)
-			{
-				Reinforcement rein = rm.getReinforcement(block);
-				if (rein != null && rein instanceof PlayerReinforcement)
-				{
-					PlayerReinforcement playerReinforcement = (PlayerReinforcement) rein;
-					if (!playerReinforcement.isInsecure()) //Only let them place against /ctinsecure
-						event.setCancelled(true);
+		if(event.getBlockPlaced().getType() != Material.REDSTONE_COMPARATOR_OFF) return;
+	
+		Comparator comparator = (Comparator)event.getBlockPlaced().getState().getData();
+		Block block = event.getBlockPlaced().getRelative(comparator.getFacing().getOppositeFace());
+		//We only care if the comparator is going placed against something with an inventory
+		if(block.getState() instanceof InventoryHolder) {
+			Reinforcement rein = rm.getReinforcement(block);
+			if (rein != null && rein instanceof PlayerReinforcement) {
+				PlayerReinforcement playerReinforcement = (PlayerReinforcement) rein;
+				if (!playerReinforcement.isInsecure()) { //Only let them place against /ctinsecure
+					Player player = event.getPlayer();
+					if (player != null) {
+						if (playerReinforcement.canAccessChests(player)) { 
+							return; // We also allow players to place against chests they can access
+						}
+						sendAndLog(player, ChatColor.RED, "You cannot place that next to a container you do not own.");
+					}
+					event.setCancelled(true);
 				}
 			}
 		}
+		
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -101,6 +101,26 @@ public class BlockListener implements Listener {
 					event.setCancelled(true);
 				}
 			}
+			return;
+		}
+
+		// So apparently read-through state can pass through an intermediary block, so lets check that too.
+		block = block.getRelative(comparator.getFacing().getOppositeFace());
+		if(block.getState() instanceof InventoryHolder) {
+			Reinforcement rein = rm.getReinforcement(Utility.getRealBlock(block));
+			if (rein != null && rein instanceof PlayerReinforcement) {
+				PlayerReinforcement playerReinforcement = (PlayerReinforcement) rein;
+				if (!playerReinforcement.isInsecure()) { //Only let them place against /ctinsecure
+					Player player = event.getPlayer();
+					if (player != null) {
+						if (playerReinforcement.canAccessChests(player)) { 
+							return; // We also allow players to place against chests they can access
+						}
+						sendAndLog(player, ChatColor.RED, "You cannot place that next to a container you do not own.");
+					}
+					event.setCancelled(true);
+				}
+			}
 		}
 		
 	}

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -87,7 +87,7 @@ public class BlockListener implements Listener {
 		Block block = event.getBlockPlaced().getRelative(comparator.getFacing().getOppositeFace());
 		//We only care if the comparator is going placed against something with an inventory
 		if(block.getState() instanceof InventoryHolder) {
-			Reinforcement rein = rm.getReinforcement(block);
+			Reinforcement rein = rm.getReinforcement(Utility.getRealBlock(block));
 			if (rein != null && rein instanceof PlayerReinforcement) {
 				PlayerReinforcement playerReinforcement = (PlayerReinforcement) rein;
 				if (!playerReinforcement.isInsecure()) { //Only let them place against /ctinsecure


### PR DESCRIPTION
Creates a config option for block breaks in Citadel to count against the tool's durability.